### PR TITLE
allow custom elements as HTML block tags

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -512,7 +512,7 @@ BlockCompiler.prototype = {
     }
     // Only block tags are accepted
     var tagName = m[1].toLowerCase();
-    if (blockTags.indexOf(tagName) == -1) {
+    if (inlineTags.indexOf(tagName) !== -1) {
       // Seems like it's a paragraph starting with inline element
       return false;
     }
@@ -705,12 +705,10 @@ BlockCompiler.prototype = {
 };
 
 /* ## Constants */
-
-var blockTags = ["address", "article", "aside", "blockquote", "canvas",
-  "dd", "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer",
-  "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
-  "noscript", "ol", "output", "p", "pre", "section", "table", "ul",
-  "style", "script"];
+var inlineTags = ["a", "b", "big", "i", "small", "tt", "abbr", "acronym",
+  "cite", "code", "dfn", "em", "kbd", "strong", "samp", "time", "var",
+  "a", "bdo", "br", "img", "map", "object", "q", "script", "span", "sub",
+  "sup", "button", "input", "label", "select", "textarea"];
 
 var htmlTagRe = /^<\/?([a-zA-Z]+)\b[\s\S]*?(\/)?>$/;
 var htmlCommentRe = /^<!--[\s\S]*?-->$/;

--- a/samples/HTML blocks.html
+++ b/samples/HTML blocks.html
@@ -9,3 +9,5 @@
 </div>
 <p>Another <strong>paragraph</strong>.</p>
 <!-- HTML comment, just like *this*-->
+<p>A third paragraph</p>
+<custom-element>Some contents</custom-element>

--- a/samples/HTML blocks.rho
+++ b/samples/HTML blocks.rho
@@ -17,3 +17,8 @@ Another *paragraph*.
 
 <!-- HTML comment, just like *this*-->
 
+A third paragraph
+
+<custom-element>
+  Some contents
+</custom-element>


### PR DESCRIPTION
Rather than checking that a tag is one of the
well known block tags we should check that
a tag is not one of the well known inline tags,
since custom elements are block tags by
default.

Perhaps this should also be customisable?